### PR TITLE
[ ipopt ] fix some issues ipopt

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -24,18 +24,14 @@ import HashedExpression.Operation
 import qualified HashedExpression.Operation
 import HashedExpression.Prettify
 import HashedExpression.Value
+import HashedExpression.Problem
 import Prelude hiding ((^))
 
 main :: IO ()
 main = do
   let x = variable2D @10 @10 "x"
-  let y = variable2D @10 @10 "y"
-  let z = variable "z"
-  let exp = z * (1 / z)
-  let valMap =
-        Map.fromList
-          [ ("x", V2D $ Array.listArray ((0, 0), (9, 9)) (replicate 50 1 ++ replicate 50 2)),
-            ("y", V2D $ Array.listArray ((0, 0), (9, 9)) (replicate 100 2)),
-            ("z", VScalar 2)
-          ]
-  print $ eval valMap exp
+  let obj = x <.> log x
+  case constructProblem obj (Constraint []) of 
+    ProblemValid p -> 
+      case generateProblemCode CSimpleConfig {output = OutputText} p Map.empty of 
+        Success proceed -> proceed "algorithms/ipopt"


### PR DESCRIPTION
@dalvescb 
#32 
There are some issues with current ipopt adapter. 
Address of `sdata` is passed as address of SharedData (which is weirdly defined as pointer to _SharedData)
```c
struct _SharedData {Number* data; int data_size; };
typedef struct _SharedData* SharedData;

```
```c
  SharedData sdata;
  ...
   status = IpoptSolve(nlp, x, NULL, &obj, mult_g, mult_x_L, mult_x_U, &sdata);
```
But later we retrieve it as SharedData

```c
Bool eval_grad_f(
   Index       n,
   Number*     x,
   Bool        new_x,
   Number*     grad_f,
   UserDataPtr user_data
)
{
  SharedData sdata = (SharedData)user_data;
  ...
```
Thus leads to invalid area of data and we just get abunch of +inf -inf after evaluations of f and grad.
So it should have been 
```c
status = IpoptSolve(nlp, x, NULL, &obj, mult_g, mult_x_L, mult_x_U, sdata);
```

But even so, it would still not work, because the `x` passed to IpoptSolve only serves as starting point and solution, not the actual working spaces of Ipopt. 
```c
  Number* x = NULL;                    /* starting point and solution vector */
```


We still need to copy value of x over ptr before evaluations, otherwise it will not converge.
```c
Bool eval_f(
   Index       n,
   Number*     x,
   Bool        new_x,
   Number*     obj_value,
   UserDataPtr _
)
{
  memcpy(ptr + VARS_START_OFFSET, x, sizeof(Number) * NUM_ACTUAL_VARIABLES);
  evaluate_objective();
  *obj_value = ptr[objective_offset];

  return TRUE;
}
```


So I made some adjustments. I also removed `SharedData` as we already have `ptr` as shared data.