### PR TITLE
Outputtext rewrite

### DIFF
--- a/embed/writeCSV.c
+++ b/embed/writeCSV.c
@@ -1,0 +1,10 @@
+  {
+    printf("Writing %{name} to %{filePath}...\n");
+    FILE *file = fopen("%{filePath}", "a");
+    int i;
+    for (i = 0; i < %{size}; i++) {
+      fprintf(file, "%{name},%d,%f\n",i,*(%{address} + i));
+      if (i + 1 < %{size}) fprintf(file, " ");
+    }
+    fclose(file);
+  }

--- a/src/HashedExpression/Codegen/CSimple.hs
+++ b/src/HashedExpression/Codegen/CSimple.hs
@@ -537,13 +537,13 @@ instance Codegen CSimpleConfig where
             | output == OutputCSV =
               renderTemplate
                 [ ("name", tt $ varName var),
-                  ("filePath", tt "ipopt_out.csv"),
+                  ("filePath", tt "data_out.csv"),
                   ("address", "ptr + " <> (tt . addressReal . nodeId $ var)),
                   ("size", tt . product . getShape . nodeId $ var)
                 ]
                 writeCSVTemplate
           writeResult = T.intercalate "\n" $
-                          ["FILE *file = fopen(\"ipopt_out.csv\",\"w\");"
+                          ["FILE *file = fopen(\"data_out.csv\",\"w\");"
                           ,"time_t time_struct = time(NULL);"
                           ,"char *time_string = ctime(&time_struct);"
                           ,"fprintf(file,\"# Generated: %s\",time_string);"

--- a/src/HashedExpression/Embed.hs
+++ b/src/HashedExpression/Embed.hs
@@ -28,6 +28,9 @@ readHDF5Template = $(embedStringFile "embed/readHDF5.c")
 writeTXTTemplate :: T.Text
 writeTXTTemplate = $(embedStringFile "embed/writeTXT.c")
 
+writeCSVTemplate :: T.Text
+writeCSVTemplate = $(embedStringFile "embed/writeCSV.c")
+
 writeHDF5Template :: T.Text
 writeHDF5Template = $(embedStringFile "embed/writeHDF5.c")
 


### PR DESCRIPTION
Since I'm working with a lot of scalar variables that each get printed to individual files with OutputText which is annoying, I created an OutputCSV mode that puts all variables in one file (data_out.csv) in a csv format of the form name,index,value (where name is the variables name, index is the index which is important if its a vector, and value is the solution value). 